### PR TITLE
fix cookie settings dialog not diplaying any choices

### DIFF
--- a/src/components/Banner.svelte
+++ b/src/components/Banner.svelte
@@ -175,7 +175,7 @@
 <div class="cookieConsentOperations" transition:fade>
   <div class="cookieConsentOperations__List">
     {#each choicesArr as choice}
-      {#if Object.hasOwnProperty.call(choicesMerged, (choice.id) && choicesMerged[choice.id])}
+      {#if Object.hasOwnProperty.call(choicesMerged, choice.id) && choicesMerged[choice.id]}
         <div
           class="cookieConsentOperations__Item"
           class:disabled={choice.id === 'necessary'}>


### PR DESCRIPTION
This PR fixes a regression introduced in 7.0.0 (via e8787b29ac067c0e06c57594abe68e463e4a7cae)

In 7.0.0 the cookie settings dialog does not display any choices and looks like this with the default options:

![Screenshot from 2020-08-21 15-08-47](https://user-images.githubusercontent.com/520864/90894116-6969f880-e3c0-11ea-86e9-84303b0c736c.png)

